### PR TITLE
Fix a bug with replacing falsey values

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -33,7 +33,7 @@
             return translate.whenUndefined(key, locale);
         } else {
             return templateData ? translation.replace(interpolateRE, function(match, param) {
-                return templateData[param] || match;
+                return templateData.hasOwnProperty(param) ? templateData[param] : match;
             }) : translation;
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -97,6 +97,7 @@ describe('translate', function() {
         assert.equal(translate('welcomeMessage', {userName: 'George'}), 'Hello George');
         assert.equal(translate('welcomeMessage', {}), 'Hello {{userName}}');
         assert.equal(translate('taskCounterMessage', {taskCounter: 4, userName: 'George'}), '4 tasks left George');
+        assert.equal(translate('taskCounterMessage', {taskCounter: 0, userName: 'George'}), '0 tasks left George');
 
     });
 


### PR DESCRIPTION
Fixes an issue where attempting to replace a templated string with a falsey value would leave the template unchanged. 